### PR TITLE
Improved: JTDateEpochMappings, the didMapObjectFromJSON callback, and made using inheritence with mappings easier.

### DIFF
--- a/JTObjectMapping/Source/JTDateMappings.h
+++ b/JTObjectMapping/Source/JTDateMappings.h
@@ -31,14 +31,15 @@
 @protocol JTDateEpochMappings <NSObject>
 
 - (NSString *)key;
-- (CGFloat)divisorForSeconds;
+- (NSTimeInterval)divisorForSeconds;
+
 
 @end
 
 @interface JTDateEpochMappings : NSObject <JTDateEpochMappings>
 @property (nonatomic, copy) NSString *key;
-@property (nonatomic) CGFloat divisorForSeconds;
+@property (nonatomic) NSTimeInterval divisorForSeconds;
 // You must specify the fraction of seconds you want: 1==seconds, 1000==milliseconds, etc.
-+ (id <JTDateEpochMappings>)mappingWithKey:(NSString *)key divisorForSeconds:(CGFloat)divisorForSeconds;
++ (id <JTDateEpochMappings>)mappingWithKey:(NSString *)key divisorForSeconds:(NSTimeInterval)divisorForSeconds;
 
 @end

--- a/JTObjectMapping/Source/JTDateMappings.m
+++ b/JTObjectMapping/Source/JTDateMappings.m
@@ -31,7 +31,7 @@
 @implementation JTDateEpochMappings
 @synthesize key, divisorForSeconds;
 
-+ (id <JTDateEpochMappings>)mappingWithKey:(NSString *)key divisorForSeconds:(CGFloat)divisorForSeconds {
++ (id <JTDateEpochMappings>)mappingWithKey:(NSString *)key divisorForSeconds:(NSTimeInterval)divisorForSeconds {
     JTDateEpochMappings *epochMapping = [[JTDateEpochMappings alloc] init];
     epochMapping.key = key;
     epochMapping.divisorForSeconds = divisorForSeconds;

--- a/JTObjectMapping/Source/JTMappings.h
+++ b/JTObjectMapping/Source/JTMappings.h
@@ -12,7 +12,7 @@
 @protocol JTMappings <NSObject>
 
 - (NSString *)key;
-- (NSDictionary *)mapping;
+- (NSMutableDictionary *)mapping;
 - (Class)targetClass;
 
 @end
@@ -22,11 +22,11 @@
 @interface JTMappings : NSObject <JTMappings>
 
 @property (nonatomic, retain) NSString *key;
-@property (nonatomic, retain) NSDictionary *mapping;
+@property (nonatomic, retain) NSMutableDictionary *mapping;
 @property (nonatomic, assign) Class targetClass;
 
 + (id <JTMappings>)mappingWithKey:(NSString *)aKey
                       targetClass:(Class)aClass
-                          mapping:(NSDictionary *)aMapping;
+                          mapping:(NSMutableDictionary *)aMapping;
 
 @end

--- a/JTObjectMapping/Source/JTMappings.m
+++ b/JTObjectMapping/Source/JTMappings.m
@@ -11,10 +11,10 @@
 @implementation JTMappings
 @synthesize key, mapping, targetClass;
 
-+ (id <JTMappings>)mappingWithKey:(NSString *)aKey targetClass:(Class)aClass mapping:(NSDictionary *)aMapping {
++ (id <JTMappings>)mappingWithKey:(NSString *)aKey targetClass:(Class)aClass mapping:(NSMutableDictionary *)aMapping {
     JTMappings *obj = [[JTMappings alloc] init];
     obj.key         = aKey;
-    obj.mapping     = aMapping;
+    obj.mapping     = [aMapping mutableCopy];
     obj.targetClass = aClass;
     return [obj autorelease];
 }

--- a/JTObjectMapping/Source/NSObject+JTObjectMapping.h
+++ b/JTObjectMapping/Source/NSObject+JTObjectMapping.h
@@ -28,7 +28,7 @@
 - (void)setValueFromDictionary:(NSDictionary *)dict mapping:(NSDictionary *)mapping;
 + (id <JTMappings>)mappingWithKey:(NSString *)key mapping:(NSDictionary *)mapping;
 + (id)objectFromJSONObject:(id <JTValidJSONResponse>)object mapping:(NSDictionary *)mapping;
-- (void)didMapObjectFromJSON;
+- (void)didMapObjectFromJSON:(id<JTValidJSONResponse>)object;
 
 @end
 


### PR DESCRIPTION
(Sorry this is all mixed into one commit.)

Now we send the original JTValidJSONResponse (dict) object with the didMapObjectFromJSON callback. (This is convenient for basic operations or properties that need to be altered before the mapping is supposed to be used.

Changed JTMappings.mapping from an NSDictionary into an NSMutableDictionary to make it easier to use with inheritence. (You can call the super method and just add items to the .mapping mutable dictionary instead of having to copy and replace it.)

Added better warning message for unhandled mapping.

Fixed bug with JTDateEpochMappings where a rounding error could cause you to be one second off.

JTDateEpochMappings now works with NSString's parsed from the JSON. (Previously it worked only with NSNumber.)

Removed unnecessary NSObject\* casts. (Did you put those in because of compiler warnings?)
