### PR TITLE
NSDate mapper with NSDateFormatter

### DIFF
--- a/JTObjectMapping/Source/JTDateMappings.h
+++ b/JTObjectMapping/Source/JTDateMappings.h
@@ -18,6 +18,6 @@
 + (id <JTValidMappingKey>)mappingWithKey:(NSString *)key dateFormatter:(NSDateFormatter *)dateFormatter;
 
 // Handly method for + [JTDateMappings mappingWithKey:divisorForSeconds:]
-+ (id <JTValidMappingKey>)mappingWithKey:(NSString *)key divisorForSeconds:(CGFloat)divisorForSeconds;
++ (id <JTValidMappingKey>)mappingWithKey:(NSString *)key divisorForSeconds:(float)divisorForSeconds;
 
 @end

--- a/JTObjectMapping/Source/JTDateMappings.m
+++ b/JTObjectMapping/Source/JTDateMappings.m
@@ -200,7 +200,7 @@
     return [JTDateFormatterMappings mappingWithKey:key dateFormatter:dateFormatter];
 }
 
-+ (id <JTValidMappingKey>)mappingWithKey:(NSString *)key divisorForSeconds:(CGFloat)divisorForSeconds {
++ (id <JTValidMappingKey>)mappingWithKey:(NSString *)key divisorForSeconds:(float)divisorForSeconds {
     return [JTDateEpochMappings mappingWithKey:key divisorForSeconds:divisorForSeconds];
 }
 


### PR DESCRIPTION
Adding NSDate mapper with a NSDateFormatter as parameter, so you can configure parameters other than dateFormat only.

I used it to be able to set the timezone.
