### PR TITLE
fixes potential memory leak static analyzer warning

### DIFF
--- a/JTObjectMapping/Source/JTMappings.m
+++ b/JTObjectMapping/Source/JTMappings.m
@@ -28,7 +28,7 @@
     JTMappings *obj = [[JTMappings alloc] init];
     obj.key         = aKey;
     obj.mapping     = [aMapping mutableCopy];
-    obj.targetClass = aClass;
+    obj.targetClass = [aClass copy];
     return [obj autorelease];
 }
 


### PR DESCRIPTION
clang static analyzer was outputting this warning, this commit addresses the problem:

JTMappings.m:31:9: Potential leak of an object
JTMappings.m:30:23: Method returns an Objective-C object with a +1 retain count
JTMappings.m:31:9: Object leaked: allocated object is not referenced later in this execution path and has a retain count of +1
